### PR TITLE
Added canvas name

### DIFF
--- a/contracts/BiddableCanvas.sol
+++ b/contracts/BiddableCanvas.sol
@@ -244,6 +244,21 @@ contract BiddableCanvas is CanvasFactory, Withdrawable {
     }
 
     /**
+    * Sets canvas name. Only for the owner of the canvas. Name can be an empty
+    * string which is the same as lack of the name.
+    */
+    function setCanvasName(uint32 _canvasId, string _name) external
+    stateOwned(_canvasId)
+    forceOwned(_canvasId)
+    {
+        Canvas storage _canvas = _getCanvas(_canvasId);
+        require(msg.sender == _canvas.owner);
+
+        _canvas.name = _name;
+        emit CanvasNameSet(_canvasId, _name);
+    }
+
+    /**
     * @notice   Returns number of canvases owned by the given address.
     */
     function balanceOf(address _owner) external view returns (uint) {

--- a/contracts/CanvasFactory.sol
+++ b/contracts/CanvasFactory.sol
@@ -30,6 +30,7 @@ contract CanvasFactory is TimeAware {
     event PixelPainted(uint32 indexed canvasId, uint32 index, uint8 color, address indexed painter);
     event CanvasFinished(uint32 indexed canvasId);
     event CanvasCreated(uint indexed canvasId);
+    event CanvasNameSet(uint indexed canvasId, string name);
 
     modifier notFinished(uint32 _canvasId) {
         require(!isCanvasFinished(_canvasId));
@@ -54,7 +55,7 @@ contract CanvasFactory is TimeAware {
         require(canvases.length < MAX_CANVAS_COUNT);
         require(activeCanvasCount < MAX_ACTIVE_CANVAS);
 
-        uint id = canvases.push(Canvas(STATE_NOT_FINISHED, 0x0, 0, 0, false)) - 1;
+        uint id = canvases.push(Canvas(STATE_NOT_FINISHED, 0x0, "", 0, 0, false)) - 1;
 
         emit CanvasCreated(id);
         activeCanvasCount++;
@@ -212,6 +213,8 @@ contract CanvasFactory is TimeAware {
         * Owner of canvas. Canvas doesn't have an owner until initial bidding ends.
         */
         address owner;
+
+        string name;
 
         /**
         * Numbers of pixels set. Canvas will be considered finished when all pixels will be set.

--- a/contracts/CryptoArt.sol
+++ b/contracts/CryptoArt.sol
@@ -79,6 +79,7 @@ contract CryptoArt is CanvasMarket {
 
     function getCanvasInfo(uint32 _canvasId) external view returns (
         uint32 id,
+        string name,
         uint32 paintedPixels,
         uint8 canvasState,
         uint initialBiddingFinishTime,
@@ -86,7 +87,7 @@ contract CryptoArt is CanvasMarket {
     ) {
         Canvas storage canvas = _getCanvas(_canvasId);
 
-        return (_canvasId, canvas.paintedPixelsCount, getCanvasState(_canvasId),
+        return (_canvasId, canvas.name, canvas.paintedPixelsCount, getCanvasState(_canvasId),
         canvas.initialBiddingFinishTime, canvas.owner);
     }
 

--- a/test/TestableArtWrapper.js
+++ b/test/TestableArtWrapper.js
@@ -106,16 +106,19 @@ export class TestableArtWrapper {
         const result = await this.instance.getCanvasInfo(canvasId);
         return {
             id: parseInt(result[0]),
-            paintedPixels: parseInt(result[1]),
-            canvasState: parseInt(result[2]),
-            initialBiddingFinishTime: parseInt(result[3]),
-            owner: result[4]
+            name: result[1],
+            paintedPixels: parseInt(result[2]),
+            canvasState: parseInt(result[3]),
+            initialBiddingFinishTime: parseInt(result[4]),
+            owner: result[5]
         };
     };
 
     getCanvasByOwner = async (owner) => await this.instance.getCanvasByOwner(owner);
 
     setMinimumBidAmount = async (amount, options = {}) => await this.instance.setMinimumBidAmount(amount, options);
+
+    setCanvasName = async (canvasId, name, options = {}) => await this.instance.setCanvasName(canvasId, name, options);
 
     /**
      * @returns {Promise<Array<String>>}
@@ -201,9 +204,8 @@ export class TestableArtWrapper {
      * Fills all canvas with 10 color.
      */
     fillWholeCanvas = async (canvasId) => {
-        for (let i = 0; i < 18; i++) {
-            await this.fillCanvas(canvasId, i * 128, (i + 1) * 128);
-        }
+        const pixelCount = await this.PIXEL_COUNT();
+        await this.fillCanvas(canvasId, 0, pixelCount, 10);
     };
 
     /**


### PR DESCRIPTION
Closes #9. 

Now it is possible to set a canvas name. Only the owner of the canvas can do it. It means it's not possible to set a name before initial bidding finishes. 
 
You can get a name using getCanvasInfo() function.  Now it looks like this: 

```Solidity
function getCanvasInfo(uint32 _canvasId) external view returns (
        uint32 id,
        string name,
        uint32 paintedPixels,
        uint8 canvasState,
        uint initialBiddingFinishTime,
        address owner
    )
```

By default, if no name was set, returns an empty string: `""`.