### PR TITLE
Implemented booking a canvas

### DIFF
--- a/contracts/BiddableCanvas.sol
+++ b/contracts/BiddableCanvas.sol
@@ -251,7 +251,8 @@ contract BiddableCanvas is CanvasFactory, Withdrawable {
     stateOwned(_canvasId)
     forceOwned(_canvasId)
     {
-        require(_name.length <= MAX_CANVAS_NAME_LENGTH);
+        bytes memory _strBytes = bytes(_name);
+        require(_strBytes.length <= MAX_CANVAS_NAME_LENGTH);
 
         Canvas storage _canvas = _getCanvas(_canvasId);
         require(msg.sender == _canvas.owner);

--- a/contracts/BiddableCanvas.sol
+++ b/contracts/BiddableCanvas.sol
@@ -251,6 +251,8 @@ contract BiddableCanvas is CanvasFactory, Withdrawable {
     stateOwned(_canvasId)
     forceOwned(_canvasId)
     {
+        require(_name.length <= MAX_CANVAS_NAME_LENGTH);
+
         Canvas storage _canvas = _getCanvas(_canvasId);
         require(msg.sender == _canvas.owner);
 

--- a/contracts/BiddableCanvas.sol
+++ b/contracts/BiddableCanvas.sol
@@ -1,12 +1,11 @@
 pragma solidity 0.4.24;
 
 import "./CanvasFactory.sol";
-import "./Withdrawable.sol";
 
 /**
 * @dev This contract takes care of initial bidding.
 */
-contract BiddableCanvas is CanvasFactory, Withdrawable {
+contract BiddableCanvas is CanvasFactory {
 
     /**
     * As it's hard to operate on floating numbers, each fee will be calculated like this:

--- a/contracts/CanvasFactory.sol
+++ b/contracts/CanvasFactory.sol
@@ -23,6 +23,7 @@ contract CanvasFactory is TimeAware {
 
     uint32 public constant MAX_CANVAS_COUNT = 1000;
     uint8 public constant MAX_ACTIVE_CANVAS = 12;
+    uint8 public constant MAX_CANVAS_NAME_LENGTH = 24;
 
     Canvas[] canvases;
     uint32 public activeCanvasCount = 0;

--- a/contracts/CanvasFactory.sol
+++ b/contracts/CanvasFactory.sol
@@ -1,11 +1,12 @@
 pragma solidity 0.4.24;
 
 import "./TimeAware.sol";
+import "./Withdrawable.sol";
 
 /**
 * @dev This contract takes care of painting on canvases, returning artworks and creating ones. 
 */
-contract CanvasFactory is TimeAware {
+contract CanvasFactory is TimeAware, Withdrawable {
 
     //@dev It means canvas is not finished yet, and bidding is not possible.
     uint8 public constant STATE_NOT_FINISHED = 0;
@@ -24,6 +25,8 @@ contract CanvasFactory is TimeAware {
     uint32 public constant MAX_CANVAS_COUNT = 1000;
     uint8 public constant MAX_ACTIVE_CANVAS = 12;
     uint8 public constant MAX_CANVAS_NAME_LENGTH = 24;
+
+    uint public bookCanvasPrice = 0.1 ether;
 
     Canvas[] canvases;
     uint32 public activeCanvasCount = 0;
@@ -53,15 +56,17 @@ contract CanvasFactory is TimeAware {
     *           There can't be more unfinished canvases than MAX_ACTIVE_CANVAS.
     */
     function createCanvas() external returns (uint canvasId) {
-        require(canvases.length < MAX_CANVAS_COUNT);
-        require(activeCanvasCount < MAX_ACTIVE_CANVAS);
+        return _createCanvasInternal(0x0);
+    }
 
-        uint id = canvases.push(Canvas(STATE_NOT_FINISHED, 0x0, "", 0, 0, false)) - 1;
+    /**
+    * @notice   Similar to createCanvas(). Additionally, books it for a caller.
+    */
+    function createAndBookCanvas() external payable returns (uint canvasId) {
+        require(msg.value >= bookCanvasPrice);
 
-        emit CanvasCreated(id);
-        activeCanvasCount++;
-
-        return id;
+        addPendingWithdrawal(owner, msg.value);
+        return _createCanvasInternal(msg.sender);
     }
 
     /**
@@ -156,6 +161,10 @@ contract CanvasFactory is TimeAware {
         return canvas.addressToCount[_address];
     }
 
+    function setBookPrice(uint _price) external onlyOwner {
+        bookCanvasPrice = _price;
+    }
+
     function _isCanvasFinished(Canvas canvas) internal pure returns (bool) {
         return canvas.paintedPixelsCount == PIXEL_COUNT;
     }
@@ -163,6 +172,18 @@ contract CanvasFactory is TimeAware {
     function _getCanvas(uint32 _canvasId) internal view returns (Canvas storage) {
         require(_canvasId < canvases.length);
         return canvases[_canvasId];
+    }
+
+    function _createCanvasInternal(address _bookedFor) private returns (uint canvasId) {
+        require(canvases.length < MAX_CANVAS_COUNT);
+        require(activeCanvasCount < MAX_ACTIVE_CANVAS);
+
+        uint id = canvases.push(Canvas(STATE_NOT_FINISHED, 0x0, _bookedFor, "", 0, 0, false)) - 1;
+
+        emit CanvasCreated(id);
+        activeCanvasCount++;
+
+        return id;
     }
 
     /**
@@ -173,6 +194,7 @@ contract CanvasFactory is TimeAware {
     notFinished(_canvasId)
     validPixelIndex(_index) {
         require(_color > 0);
+        require(_canvas.bookedFor == 0x0 || _canvas.bookedFor == msg.sender);
         if (_canvas.pixels[_index].painter != 0x0) {
             //it means this pixel has been already set!
             revert();
@@ -214,6 +236,12 @@ contract CanvasFactory is TimeAware {
         * Owner of canvas. Canvas doesn't have an owner until initial bidding ends.
         */
         address owner;
+
+        /**
+        * Booked by this address. It means that only that address can draw on the canvas.
+        * 0x0 if everybody can paint on the canvas.
+        */
+        address bookedFor;
 
         string name;
 

--- a/contracts/CanvasFactory.sol
+++ b/contracts/CanvasFactory.sol
@@ -33,7 +33,7 @@ contract CanvasFactory is TimeAware, Withdrawable {
 
     event PixelPainted(uint32 indexed canvasId, uint32 index, uint8 color, address indexed painter);
     event CanvasFinished(uint32 indexed canvasId);
-    event CanvasCreated(uint indexed canvasId);
+    event CanvasCreated(uint indexed canvasId, address indexed bookedFor);
     event CanvasNameSet(uint indexed canvasId, string name);
 
     modifier notFinished(uint32 _canvasId) {
@@ -180,7 +180,7 @@ contract CanvasFactory is TimeAware, Withdrawable {
 
         uint id = canvases.push(Canvas(STATE_NOT_FINISHED, 0x0, _bookedFor, "", 0, 0, false)) - 1;
 
-        emit CanvasCreated(id);
+        emit CanvasCreated(id, _bookedFor);
         activeCanvasCount++;
 
         return id;

--- a/contracts/CryptoArt.sol
+++ b/contracts/CryptoArt.sol
@@ -83,12 +83,13 @@ contract CryptoArt is CanvasMarket {
         uint32 paintedPixels,
         uint8 canvasState,
         uint initialBiddingFinishTime,
-        address owner
+        address owner,
+        address bookedFor
     ) {
         Canvas storage canvas = _getCanvas(_canvasId);
 
         return (_canvasId, canvas.name, canvas.paintedPixelsCount, getCanvasState(_canvasId),
-        canvas.initialBiddingFinishTime, canvas.owner);
+        canvas.initialBiddingFinishTime, canvas.owner, canvas.bookedFor);
     }
 
     function getCanvasByOwner(address _owner) external view returns (uint32[]) {

--- a/test/TestableArtWrapper.js
+++ b/test/TestableArtWrapper.js
@@ -20,7 +20,13 @@ export class TestableArtWrapper {
 
     minimumBidAmount = async () => parseInt(await this.instance.minimumBidAmount());
 
+    bookCanvasPrice = async () => await this.instance.bookCanvasPrice();
+
     createCanvas = async () => await this.instance.createCanvas();
+
+    createAndBookCanvas = async (options = {}) => await this.instance.createAndBookCanvas(options);
+
+    setBookPrice = async (amount, options = {}) => await this.instance.setBookPrice(amount, options);
 
     activeCanvasCount = async () => {
         const activeCount = await this.instance.activeCanvasCount();
@@ -110,7 +116,8 @@ export class TestableArtWrapper {
             paintedPixels: parseInt(result[2]),
             canvasState: parseInt(result[3]),
             initialBiddingFinishTime: parseInt(result[4]),
-            owner: result[5]
+            owner: result[5],
+            bookedFor: result[6]
         };
     };
 

--- a/test/creationTests.js
+++ b/test/creationTests.js
@@ -8,7 +8,7 @@ chai.use(require('chai-arrays')).should();
 
 const TestableArt = artifacts.require("TestableArt");
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
-const eth = new BigNumber("100000000000000000");
+const eth = new BigNumber("1000000000000000000");
 
 contract('Simple canvas creation', async (accounts) => {
 
@@ -37,9 +37,13 @@ contract('Simple canvas creation', async (accounts) => {
 
         const activeCount = await instance.activeCanvasCount();
         const count = await instance.canvasCount();
+        const info1 = await instance.getCanvasInfo(0);
+        const info2 = await instance.getCanvasInfo(1);
 
         activeCount.should.be.equal(2);
         count.should.be.equal(2);
+        info1.bookedFor.should.be.eq(ZERO_ADDRESS);
+        info2.bookedFor.should.be.eq(ZERO_ADDRESS);
     });
 
     it('should all authors be address 0x0', async () => {
@@ -65,6 +69,62 @@ contract('Simple canvas creation', async (accounts) => {
         const instance = new TestableArtWrapper(await TestableArt.deployed());
         const active = await instance.getCanvasByState(0);
         active.should.be.equalTo([0, 1]);
+    });
+
+    it('should disallow to book canvas for too small value', async function () {
+        const instance = new TestableArtWrapper(await TestableArt.deployed());
+        const value = eth.multipliedBy(0.09).toNumber();
+
+        return instance.createAndBookCanvas({value}).should.be.rejected;
+    });
+
+    it('should allow to create and book canvas', async function () {
+        const instance = new TestableArtWrapper(await TestableArt.deployed());
+        const value = eth.multipliedBy(0.1).toNumber();
+
+        await instance.createAndBookCanvas({from: accounts[1], value: value});
+        const info = await instance.getCanvasInfo(2);
+
+        info.bookedFor.should.be.eq(accounts[1]);
+    });
+
+    it('should disallow to set pixels if booked for another address', async function () {
+        const instance = new TestableArtWrapper(await TestableArt.deployed());
+        return instance.setPixel(2, 0, 10, {from: accounts[0]}).should.be.rejected;
+    });
+
+    it('should allow to set pixels on booked canvas', async function () {
+        const instance = new TestableArtWrapper(await TestableArt.deployed());
+        await instance.setPixel(2, 0, 10, {from: accounts[1]});
+
+        const pixelAuthor = await instance.getPixelAuthor(2, 0);
+        pixelAuthor.should.be.eq(accounts[1]);
+    });
+
+    it('should disallow to change booking price if not called by the owner', async function () {
+        const instance = new TestableArtWrapper(await TestableArt.deployed());
+        return instance.setBookPrice(eth.toNumber(), {from: accounts[1]}).should.be.rejected;
+    });
+
+    it('should change booking price', async function () {
+        const instance = new TestableArtWrapper(await TestableArt.deployed());
+        const oldValue = eth.multipliedBy(0.1).toNumber();
+        await instance.setBookPrice(eth.toNumber(), {from: accounts[0]});
+
+        const bookingPrice = await instance.bookCanvasPrice();
+        bookingPrice.eq(eth).should.be.true;
+
+        return instance.createAndBookCanvas({from: accounts[1], value: oldValue}).should.be.rejected;
+    });
+
+    it('should allow to create and book canvas after price change', async function () {
+        const instance = new TestableArtWrapper(await TestableArt.deployed());
+        const value = eth.toNumber();
+
+        await instance.createAndBookCanvas({from: accounts[5], value: value});
+        const info = await instance.getCanvasInfo(3);
+
+        info.bookedFor.should.be.eq(accounts[5]);
     });
 
     afterEach(async () => {
@@ -154,7 +214,7 @@ contract('Canvas creation limit', async (accounts) => {
     it('should dissallow to change canvas name if longer than 24 chars', async function () {
         const instance = new TestableArtWrapper(await TestableArt.deployed());
         const nameToSet = "my long name that is cool";
-        
+
         return instance.setCanvasName(1, nameToSet, {from: accounts[0]}).should.be.rejected;
     });
 

--- a/test/creationTests.js
+++ b/test/creationTests.js
@@ -151,6 +151,13 @@ contract('Canvas creation limit', async (accounts) => {
         return instance.setCanvasName(1, "1231", {from: accounts[1]}).should.be.rejected;
     });
 
+    it('should dissallow to change canvas name if longer than 24 chars', async function () {
+        const instance = new TestableArtWrapper(await TestableArt.deployed());
+        const nameToSet = "my long name that is cool";
+        
+        return instance.setCanvasName(1, nameToSet, {from: accounts[0]}).should.be.rejected;
+    });
+
     it('should change canvas name', async function () {
         const instance = new TestableArtWrapper(await TestableArt.deployed());
         const nameToSet = "name";

--- a/test/gasCostCalculator.js
+++ b/test/gasCostCalculator.js
@@ -136,12 +136,74 @@ contract('Contract gas calculator', async (accounts) => {
     /**
      * Account 1 wins initial bidding
      */
-    it('calculate securing cost', async () => {
+    it('buying canvas', async () => {
         const instance = new TestableArtWrapper(await TestableArt.deployed());
         await instance.pushTimeForward(48);
 
         const state = await instance.getCanvasState(0);
         state.should.be.eq(STATE_OWNED);
+    });
+
+    it('calculate setting canvas name cost', async function () {
+        const instance = new TestableArtWrapper(await TestableArt.deployed());
+
+        let name = "01234";
+        let transaction = await instance.setCanvasName(0, name, {from: accounts[1]});
+        let cost = transaction.receipt.gasUsed;
+        gasCosts.push(['setCanvasName() [5 char, first time]', cost]);
+
+        name = "a";
+        transaction = await instance.setCanvasName(0, name, {from: accounts[1]});
+        cost = transaction.receipt.gasUsed;
+        gasCosts.push(['setCanvasName() [1 char]', cost]);
+
+        name = "abcde";
+        transaction = await instance.setCanvasName(0, name, {from: accounts[1]});
+        cost = transaction.receipt.gasUsed;
+        gasCosts.push(['setCanvasName() [5 chars]', cost]);
+
+        name = "aąeęi";
+        transaction = await instance.setCanvasName(0, name, {from: accounts[1]});
+        cost = transaction.receipt.gasUsed;
+        gasCosts.push(['setCanvasName() [5 chars including 2 special]', cost]);
+
+        name = "0123456789";
+        transaction = await instance.setCanvasName(0, name, {from: accounts[1]});
+        cost = transaction.receipt.gasUsed;
+        gasCosts.push(['setCanvasName() [10 chars]', cost]);
+
+        name = "01234567ź€";
+        transaction = await instance.setCanvasName(0, name, {from: accounts[1]});
+        cost = transaction.receipt.gasUsed;
+        gasCosts.push(['setCanvasName() [10 chars, including 2 special]', cost]);
+
+        name = "NzTkeT77vUe2VaElco9qNzTkeT77vUe2VaElco9q";
+        transaction = await instance.setCanvasName(0, name, {from: accounts[1]});
+        cost = transaction.receipt.gasUsed;
+        gasCosts.push(['setCanvasName() [20 chars, including 2 special]', cost]);
+
+        name = "NzTkeT77vUe2VaElco9qNzTkeT77vUe2VaElco9qNzTkeT77vUe2VaElco9qNzTkeT77vUe2VaElco9q";
+        transaction = await instance.setCanvasName(0, name, {from: accounts[1]});
+        cost = transaction.receipt.gasUsed;
+        gasCosts.push(['setCanvasName() [40 chars, including 2 special]', cost]);
+
+        name = "NzTkeT77vUe2VaElco9q6zVYmI0EifTKb3b826c1oNwnYPyS5xB1lVqDr5r xUrcSYRQGu6TnrgADbMro32UuJgTYHkGKGkLk6Yj";
+        transaction = await instance.setCanvasName(0, name, {from: accounts[1]});
+        cost = transaction.receipt.gasUsed;
+        gasCosts.push(['setCanvasName() [100 chars]', cost]);
+
+        name = "NzTkeT77vUe2VaElco9q6zVYmI0EifTKb3b826c1oNwnYPyS5xB1lVqDr5r xUrcSYRQGu6TnrgADbMro32UuJgTYHkGKGkLk6YjNzTkeT77vUe2VaElco9q6zVYmI0EifTKb3b826c1oNwnYPyS5xB1lVqDr5r xUrcSYRQGu6TnrgADbMro32UuJgTYHkGKGkLk6Yj";
+        transaction = await instance.setCanvasName(0, name, {from: accounts[1]});
+        cost = transaction.receipt.gasUsed;
+        gasCosts.push(['setCanvasName() [200 chars]', cost]);
+
+        name = "NzTkeT77vUe2VaElco9q6zVYmI0EifTKb3b826c1oNwnYPyS5xB1lVqDr5r xUrcSYRQGu6TnrgADbMro32UuJgTYHkGKGkLk6YjNzTkeT77vUe2VaElco9q6zVYmI0EifTKb3b826c1oNwnYPyS5xB1lVqDr5r xUrcSYRQGu6TnrgADbMro32UuJgTYHkGKGkLk6YjNzTkeT77vUe2VaElco9q6zVYmI0EifTKb3b826c1oNwnYPyS5xB1lVqDr5r xUrcSYRQGu6TnrgADbMro32UuJgTYHkGKGkLk6YjNzTkeT77vUe2VaElco9q6zVYmI0EifTKb3b826c1oNwnYPyS5xB1lVqDr5r xUrcSYRQGu6TnrgADbMro32UuJgTYHkGKGkLk6YjNzTkeT77vUe2VaElco9q6zVYmI0EifTKb3b826c1oNwnYPyS5xB1lVqDr5r xUrcSYRQGu6TnrgADbMro32UuJgTYHkGKGkLk6YjNzTkeT77vUe2VaElco9q6zVYmI0EifTKb3b826c1oNwnYPyS5xB1lVqDr5r xUrcSYRQGu6TnrgADbMro32UuJgTYHkGKGkLk6Yj";
+        transaction = await instance.setCanvasName(0, name, {from: accounts[1]});
+        cost = transaction.receipt.gasUsed;
+        gasCosts.push(['setCanvasName() [600 chars]', cost]);
+
+        const setName = (await instance.getCanvasInfo(0)).name;
+        setName.should.be.eq(setName);
     });
 
     it('calculate withdraw reward cost', async () => {

--- a/test/gasCostCalculator.js
+++ b/test/gasCostCalculator.js
@@ -119,6 +119,19 @@ contract('Contract gas calculator', async (accounts) => {
         gasCosts.push(['setPixels() [1 pixels]', cost]);
     });
 
+    it('calculate booking cost', async () => {
+        const instance = new TestableArtWrapper(await TestableArt.deployed());
+
+        let transaction = await instance.createAndBookCanvas({from: accounts[0], value: eth.toNumber()});
+        let cost = transaction.receipt.gasUsed;
+        gasCosts.push(['createAndBookCanvas()', cost]);
+
+        transaction = await instance.setBookPrice(eth.multipliedBy(2).toNumber(), {from: accounts[0]});
+        cost = transaction.receipt.gasUsed;
+        gasCosts.push(['setBookPrice()', cost]);
+    });
+
+
     it('calculate making bid cost', async () => {
         const instance = new TestableArtWrapper(await TestableArt.deployed());
 

--- a/test/gasCostCalculator.js
+++ b/test/gasCostCalculator.js
@@ -197,13 +197,18 @@ contract('Contract gas calculator', async (accounts) => {
         cost = transaction.receipt.gasUsed;
         gasCosts.push(['setCanvasName() [200 chars]', cost]);
 
-        name = "NzTkeT77vUe2VaElco9q6zVYmI0EifTKb3b826c1oNwnYPyS5xB1lVqDr5r xUrcSYRQGu6TnrgADbMro32UuJgTYHkGKGkLk6YjNzTkeT77vUe2VaElco9q6zVYmI0EifTKb3b826c1oNwnYPyS5xB1lVqDr5r xUrcSYRQGu6TnrgADbMro32UuJgTYHkGKGkLk6YjNzTkeT77vUe2VaElco9q6zVYmI0EifTKb3b826c1oNwnYPyS5xB1lVqDr5r xUrcSYRQGu6TnrgADbMro32UuJgTYHkGKGkLk6YjNzTkeT77vUe2VaElco9q6zVYmI0EifTKb3b826c1oNwnYPyS5xB1lVqDr5r xUrcSYRQGu6TnrgADbMro32UuJgTYHkGKGkLk6YjNzTkeT77vUe2VaElco9q6zVYmI0EifTKb3b826c1oNwnYPyS5xB1lVqDr5r xUrcSYRQGu6TnrgADbMro32UuJgTYHkGKGkLk6YjNzTkeT77vUe2VaElco9q6zVYmI0EifTKb3b826c1oNwnYPyS5xB1lVqDr5r xUrcSYRQGu6TnrgADbMro32UuJgTYHkGKGkLk6Yj";
+        name = "NzTkeT77vUe2VaElco9q6zVYmI0EifTKb3b826c1oNwnYPyS5xB1lVqDr5r xUrcSYRQGu6TnrgADbMro32UuJgTYHkGKGkLk6YjNzTkeT77vUe2VaElco9q6zVYmI0EifTKb3b826c1oNwnYPyS5xB1lVqDr5r xUrcSYRQGu6TnrgADbMro32UuJgTYHkGKGkLk6YjNzTkeT77vUe2VaElco9q6zVYmI0EifTKb3b826c1oNwnYPyS5xB1lVqDr5r xUrcSYRQGu6TnrgADbMro32UuJgTYHkGKGkLk6YjNzTkeT77vUe2VaElco9q6zVYmI0EifTKb3b826c1oNwnYPyS5xB1lVqDr5r xUrcSYRQGu6TnrgADbMro32UuJgTYHkGKGkLk6Yj09876T77vUe2VaElco9q6zVYmI0EifTKb3b826c1oNwnYPyS5xB1lVqDr5r xUrcSYRQGu6TnrgADbMro32UuJgTYHkGKGkLk6YjNzTkeT77vUe2VaElco9q6zVYmI0EifTKb3b826c1oNwnYPyS5xB1lVqDr5r xUrcSYRQGu6TnrgADbMro32UuJgTYHkGKGkLk6Yj";
         transaction = await instance.setCanvasName(0, name, {from: accounts[1]});
         cost = transaction.receipt.gasUsed;
         gasCosts.push(['setCanvasName() [600 chars]', cost]);
 
         const setName = (await instance.getCanvasInfo(0)).name;
         setName.should.be.eq(setName);
+
+        name = "";
+        transaction = await instance.setCanvasName(0, name, {from: accounts[1]});
+        cost = transaction.receipt.gasUsed;
+        gasCosts.push(['setCanvasName() [empty]', cost]);
     });
 
     it('calculate withdraw reward cost', async () => {

--- a/test/gasCostCalculator.js
+++ b/test/gasCostCalculator.js
@@ -147,10 +147,10 @@ contract('Contract gas calculator', async (accounts) => {
     it('calculate setting canvas name cost', async function () {
         const instance = new TestableArtWrapper(await TestableArt.deployed());
 
-        let name = "01234";
+        let name = "a";
         let transaction = await instance.setCanvasName(0, name, {from: accounts[1]});
         let cost = transaction.receipt.gasUsed;
-        gasCosts.push(['setCanvasName() [5 char, first time]', cost]);
+        gasCosts.push(['setCanvasName() [1 char, first time]', cost]);
 
         name = "a";
         transaction = await instance.setCanvasName(0, name, {from: accounts[1]});
@@ -177,30 +177,21 @@ contract('Contract gas calculator', async (accounts) => {
         cost = transaction.receipt.gasUsed;
         gasCosts.push(['setCanvasName() [10 chars, including 2 special]', cost]);
 
-        name = "NzTkeT77vUe2VaElco9qNzTkeT77vUe2VaElco9q";
+        name = "NzTkeT77vUe2Vąć";
+        transaction = await instance.setCanvasName(0, name, {from: accounts[1]});
+        cost = transaction.receipt.gasUsed;
+        gasCosts.push(['setCanvasName() [15 chars, including 2 special]', cost]);
+
+        name = "NzTkeT77vUe2VaElcoź€";
         transaction = await instance.setCanvasName(0, name, {from: accounts[1]});
         cost = transaction.receipt.gasUsed;
         gasCosts.push(['setCanvasName() [20 chars, including 2 special]', cost]);
 
-        name = "NzTkeT77vUe2VaElco9qNzTkeT77vUe2VaElco9qNzTkeT77vUe2VaElco9qNzTkeT77vUe2VaElco9q";
+        name = "NzTkeT77vUe2VaElco9q1234";
         transaction = await instance.setCanvasName(0, name, {from: accounts[1]});
         cost = transaction.receipt.gasUsed;
-        gasCosts.push(['setCanvasName() [40 chars, including 2 special]', cost]);
+        gasCosts.push(['setCanvasName() [24 chars]', cost]);
 
-        name = "NzTkeT77vUe2VaElco9q6zVYmI0EifTKb3b826c1oNwnYPyS5xB1lVqDr5r xUrcSYRQGu6TnrgADbMro32UuJgTYHkGKGkLk6Yj";
-        transaction = await instance.setCanvasName(0, name, {from: accounts[1]});
-        cost = transaction.receipt.gasUsed;
-        gasCosts.push(['setCanvasName() [100 chars]', cost]);
-
-        name = "NzTkeT77vUe2VaElco9q6zVYmI0EifTKb3b826c1oNwnYPyS5xB1lVqDr5r xUrcSYRQGu6TnrgADbMro32UuJgTYHkGKGkLk6YjNzTkeT77vUe2VaElco9q6zVYmI0EifTKb3b826c1oNwnYPyS5xB1lVqDr5r xUrcSYRQGu6TnrgADbMro32UuJgTYHkGKGkLk6Yj";
-        transaction = await instance.setCanvasName(0, name, {from: accounts[1]});
-        cost = transaction.receipt.gasUsed;
-        gasCosts.push(['setCanvasName() [200 chars]', cost]);
-
-        name = "NzTkeT77vUe2VaElco9q6zVYmI0EifTKb3b826c1oNwnYPyS5xB1lVqDr5r xUrcSYRQGu6TnrgADbMro32UuJgTYHkGKGkLk6YjNzTkeT77vUe2VaElco9q6zVYmI0EifTKb3b826c1oNwnYPyS5xB1lVqDr5r xUrcSYRQGu6TnrgADbMro32UuJgTYHkGKGkLk6YjNzTkeT77vUe2VaElco9q6zVYmI0EifTKb3b826c1oNwnYPyS5xB1lVqDr5r xUrcSYRQGu6TnrgADbMro32UuJgTYHkGKGkLk6YjNzTkeT77vUe2VaElco9q6zVYmI0EifTKb3b826c1oNwnYPyS5xB1lVqDr5r xUrcSYRQGu6TnrgADbMro32UuJgTYHkGKGkLk6Yj09876T77vUe2VaElco9q6zVYmI0EifTKb3b826c1oNwnYPyS5xB1lVqDr5r xUrcSYRQGu6TnrgADbMro32UuJgTYHkGKGkLk6YjNzTkeT77vUe2VaElco9q6zVYmI0EifTKb3b826c1oNwnYPyS5xB1lVqDr5r xUrcSYRQGu6TnrgADbMro32UuJgTYHkGKGkLk6Yj";
-        transaction = await instance.setCanvasName(0, name, {from: accounts[1]});
-        cost = transaction.receipt.gasUsed;
-        gasCosts.push(['setCanvasName() [600 chars]', cost]);
 
         const setName = (await instance.getCanvasInfo(0)).name;
         setName.should.be.eq(setName);


### PR DESCRIPTION
Closes #11 
From now on it's is possible to use a function `createAndBookCanvas()` to create a canvas and disallow other users to paint on it. It's required to send `0.1 eth` to do that. It's added to the pending withdrawals of the owner of the contract. 

API changes: 
* Event emitted after creating a canvas looks like this: `event CanvasCreated(uint indexed canvasId, address indexed bookedFor)`
* `bookCanvasPrice()` is a price required to call `createAndBookCanvas()`
* `function setBookPrice(uint _price)` can only be called by the owner of the contract. Changes price required to create and book a canvas.  
* `getCanvasInfo()` returns additional info: 
```Solidity
function getCanvasInfo(uint32 _canvasId) external view returns (
         uint32 id,
         string name,
         uint32 paintedPixels,
         uint8 canvasState,
         uint initialBiddingFinishTime,
        address owner
        address owner,
        address bookedFor
     )
```
* Now canvas name can max be 24 characters 