### PR TITLE
Enhanced rewards system. 

### DIFF
--- a/contracts/BiddableCanvas.sol
+++ b/contracts/BiddableCanvas.sol
@@ -1,24 +1,11 @@
 pragma solidity 0.4.24;
 
-import "./CanvasFactory.sol";
+import "./RewardableCanvas.sol";
 
 /**
 * @dev This contract takes care of initial bidding.
 */
-contract BiddableCanvas is CanvasFactory {
-
-    /**
-    * As it's hard to operate on floating numbers, each fee will be calculated like this:
-    * PRICE * COMMISSION / COMMISSION_DIVIDER. It's impossible to keep float number here.
-    *
-    * ufixed COMMISSION = 0.039; may seem useful, but it's not possible to multiply ufixed * uint.
-    */
-    uint public constant COMMISSION = 39;
-    uint public constant COMMISSION_DIVIDER = 1000;
-
-    uint8 public constant ACTION_INITIAL_BIDDING = 0;
-    uint8 public constant ACTION_SELL_OFFER_ACCEPTED = 1;
-    uint8 public constant ACTION_BUY_OFFER_ACCEPTED = 2;
+contract BiddableCanvas is RewardableCanvas {
 
     uint public constant BIDDING_DURATION = 48 hours;
 
@@ -28,35 +15,6 @@ contract BiddableCanvas is CanvasFactory {
     uint public minimumBidAmount = 0.1 ether;
 
     event BidPosted(uint32 indexed canvasId, address indexed bidder, uint amount, uint finishTime);
-    event RewardAddedToWithdrawals(uint32 indexed canvasId, address indexed toAddress, uint amount);
-    event CommissionAddedToWithdrawals(uint32 indexed canvasId, uint amount, uint8 indexed action);
-
-    modifier stateBidding(uint32 _canvasId) {
-        require(getCanvasState(_canvasId) == STATE_INITIAL_BIDDING);
-        _;
-    }
-
-    modifier stateOwned(uint32 _canvasId) {
-        require(getCanvasState(_canvasId) == STATE_OWNED);
-        _;
-    }
-
-    /**
-    * Ensures that canvas's saved state is STATE_OWNED.
-    *
-    * Because initial bidding is based on current time, we had to find a way to
-    * trigger saving new canvas state. Every transaction (not a call) that
-    * requires state owned should use it modifier as a last one.
-    *
-    * Thank's to that, we can make sure, that canvas state gets updated.
-    */
-    modifier forceOwned(uint32 _canvasId) {
-        Canvas storage canvas = _getCanvas(_canvasId);
-        if (canvas.state != STATE_OWNED) {
-            canvas.state = STATE_OWNED;
-        }
-        _;
-    }
 
     /**
     * Places bid for canvas that is in the state STATE_INITIAL_BIDDING.
@@ -88,6 +46,8 @@ contract BiddableCanvas is CanvasFactory {
         canvas.owner = msg.sender;
         addressToCount[msg.sender]++;
 
+        _registerBid(_canvasId, msg.value);
+
         emit BidPosted(_canvasId, msg.sender, msg.value, canvas.initialBiddingFinishTime);
     }
 
@@ -95,169 +55,16 @@ contract BiddableCanvas is CanvasFactory {
     * @notice   Returns last bid for canvas. If the initial bidding has been
     *           already finished that will be winning offer.
     */
-    function getLastBidForCanvas(uint32 _canvasId) external view returns (uint32 canvasId, address bidder, uint amount, uint finishTime) {
+    function getLastBidForCanvas(uint32 _canvasId) external view returns (
+        uint32 canvasId,
+        address bidder,
+        uint amount,
+        uint finishTime
+    ) {
         Bid storage bid = bids[_canvasId];
         Canvas storage canvas = _getCanvas(_canvasId);
 
         return (_canvasId, bid.bidder, bid.amount, canvas.initialBiddingFinishTime);
-    }
-
-    /**
-    * @notice   Returns current canvas state.
-    */
-    function getCanvasState(uint32 _canvasId) public view returns (uint8) {
-        Canvas storage canvas = _getCanvas(_canvasId);
-        if (canvas.state != STATE_INITIAL_BIDDING) {
-            //if state is set to owned, or not finished
-            //it means it doesn't depend on current time -
-            //we don't have to double check
-            return canvas.state;
-        }
-
-        //state initial bidding - as that state depends on
-        //current time, we have to double check if initial bidding
-        //hasn't finish yet
-        uint finishTime = canvas.initialBiddingFinishTime;
-        if (finishTime == 0 || finishTime > getTime()) {
-            return STATE_INITIAL_BIDDING;
-
-        } else {
-            return STATE_OWNED;
-        }
-    }
-
-    /**
-    * @notice   Returns all canvas' id for a given state.
-    */
-    function getCanvasByState(uint8 _state) external view returns (uint32[]) {
-        uint size;
-        if (_state == STATE_NOT_FINISHED) {
-            size = activeCanvasCount;
-        } else {
-            size = getCanvasCount() - activeCanvasCount;
-        }
-
-        uint32[] memory result = new uint32[](size);
-        uint currentIndex = 0;
-
-        for (uint32 i = 0; i < canvases.length; i++) {
-            if (getCanvasState(i) == _state) {
-                result[currentIndex] = i;
-                currentIndex++;
-            }
-        }
-
-        return _slice(result, 0, currentIndex);
-    }
-
-    /**
-    * @notice   Returns reward for painting pixels in wei. That reward is proportional
-    *           to number of set pixels. For example let's assume that the address has painted
-    *           2048 pixels, which is 50% of all pixels. He will be rewarded
-    *           with 50% of winning bid minus fee.
-    */
-    function calculateReward(uint32 _canvasId, address _address)
-    public
-    view
-    stateOwned(_canvasId)
-    returns (uint32 pixelsCount, uint reward, bool isPaid) {
-
-        Bid storage bid = bids[_canvasId];
-        Canvas storage canvas = _getCanvas(_canvasId);
-
-        uint32 paintedPixels = getPaintedPixelsCountByAddress(_address, _canvasId);
-        uint pricePerPixel = _calculatePricePerPixel(bid.amount);
-        uint _reward = paintedPixels * pricePerPixel;
-
-        return (paintedPixels, _reward, canvas.isAddressPaid[_address]);
-    }
-
-    /**
-    * Withdraws reward for contributing in canvas. Calculating reward has to be triggered
-    * and calculated per canvas. Because of that it is not enough to call function
-    * withdraw(). Caller has to call  addRewardToPendingWithdrawals() separately.
-    */
-    function addRewardToPendingWithdrawals(uint32 _canvasId)
-    external
-    stateOwned(_canvasId)
-    forceOwned(_canvasId) {
-        Canvas storage canvas = _getCanvas(_canvasId);
-
-        uint32 pixelCount;
-        uint reward;
-        bool isPaid;
-        (pixelCount, reward, isPaid) = calculateReward(_canvasId, msg.sender);
-
-        require(pixelCount > 0);
-        require(reward > 0);
-        require(!isPaid);
-
-        canvas.isAddressPaid[msg.sender] = true;
-        addPendingWithdrawal(msg.sender, reward);
-
-        emit RewardAddedToWithdrawals(_canvasId, msg.sender, reward);
-    }
-
-    /**
-    * @notice   Calculates commission that has been charged for selling the canvas.
-    */
-    function calculateCommission(uint32 _canvasId)
-    public
-    view
-    stateOwned(_canvasId)
-    returns (uint commission, bool isPaid) {
-
-        Bid storage bid = bids[_canvasId];
-        Canvas storage canvas = _getCanvas(_canvasId);
-
-        uint _commission;
-        uint _pricePerPixel;
-        (_commission, _pricePerPixel) = _splitMoney(bid.amount);
-
-        return (_commission, canvas.isCommissionPaid);
-    }
-
-    /**
-    * @notice   Only for the owner of the contract. Adds commission to the owner's
-    *           pending withdrawals.
-    */
-    function addCommissionToPendingWithdrawals(uint32 _canvasId)
-    external
-    onlyOwner
-    stateOwned(_canvasId)
-    forceOwned(_canvasId) {
-
-        Canvas storage canvas = _getCanvas(_canvasId);
-
-        uint commission;
-        bool isPaid;
-        (commission, isPaid) = calculateCommission(_canvasId);
-
-        require(commission > 0);
-        require(!isPaid);
-
-        canvas.isCommissionPaid = true;
-        addPendingWithdrawal(owner, commission);
-
-        emit CommissionAddedToWithdrawals(_canvasId, commission, ACTION_INITIAL_BIDDING);
-    }
-
-    /**
-    * Sets canvas name. Only for the owner of the canvas. Name can be an empty
-    * string which is the same as lack of the name.
-    */
-    function setCanvasName(uint32 _canvasId, string _name) external
-    stateOwned(_canvasId)
-    forceOwned(_canvasId)
-    {
-        bytes memory _strBytes = bytes(_name);
-        require(_strBytes.length <= MAX_CANVAS_NAME_LENGTH);
-
-        Canvas storage _canvas = _getCanvas(_canvasId);
-        require(msg.sender == _canvas.owner);
-
-        _canvas.name = _name;
-        emit CanvasNameSet(_canvasId, _name);
     }
 
     /**
@@ -272,62 +79,6 @@ contract BiddableCanvas is CanvasFactory {
     */
     function setMinimumBidAmount(uint _amount) external onlyOwner {
         minimumBidAmount = _amount;
-    }
-
-    /**
-    * Splits money between owner of the contract and painters.
-    * Returned commission may be slightly a bit higher then percentage value.
-    * It's caused by the fact that _calculatePricePerPixel() function
-    * operates on the integer values. Division that is calculated over there
-    * may leave a remainder.
-    */
-    function _splitMoney(uint _amount) internal pure returns (
-        uint commission,
-        uint pricePerPixel
-    ) {
-        uint totalRewards = _calculateTotalRewards(_amount);
-        uint totalCommission = _amount - totalRewards;
-
-        return (totalCommission, _calculatePricePerPixel(_amount));
-    }
-
-    function _calculatePricePerPixel(uint _totalPrice) private pure returns (uint) {
-        return (_totalPrice - _calculateCut(_totalPrice)) / PIXEL_COUNT;
-    }
-
-    /**
-    * Calculates total amount of rewards to be paid.
-    */
-    function _calculateTotalRewards(uint _totalPrice) private pure returns (uint) {
-        return PIXEL_COUNT * _calculatePricePerPixel(_totalPrice);
-    }
-
-    /**
-    * Calculates cut from the value. Currently 3.9%.
-    */
-    function _calculateCut(uint _amount) internal pure returns (uint) {
-        return (_amount * COMMISSION) / COMMISSION_DIVIDER;
-    }
-
-    /**
-    * @dev  Slices array from start (inclusive) to end (exclusive).
-    *       Doesn't modify input array.
-    */
-    function _slice(uint32[] memory _array, uint _start, uint _end) internal pure returns (uint32[]) {
-        require(_start <= _end);
-
-        if (_start == 0 && _end == _array.length) {
-            return _array;
-        }
-
-        uint size = _end - _start;
-        uint32[] memory sliced = new uint32[](size);
-
-        for (uint i = 0; i < size; i++) {
-            sliced[i] = _array[i + _start];
-        }
-
-        return sliced;
     }
 
     struct Bid {

--- a/contracts/CanvasFactory.sol
+++ b/contracts/CanvasFactory.sol
@@ -18,9 +18,9 @@ contract CanvasFactory is TimeAware, Withdrawable {
     //@dev canvas has been sold, and has the owner
     uint8 public constant STATE_OWNED = 2;
 
-    uint8 public constant WIDTH = 48;
-    uint8 public constant HEIGHT = 48;
-    uint32 public constant PIXEL_COUNT = 2304; //WIDTH * HEIGHT doesn't work for some reason
+    uint8 public constant WIDTH = 5;
+    uint8 public constant HEIGHT = 5;
+    uint32 public constant PIXEL_COUNT = 25; //WIDTH * HEIGHT doesn't work for some reason
 
     uint32 public constant MAX_CANVAS_COUNT = 1000;
     uint8 public constant MAX_ACTIVE_CANVAS = 12;

--- a/contracts/CanvasFactory.sol
+++ b/contracts/CanvasFactory.sol
@@ -18,9 +18,9 @@ contract CanvasFactory is TimeAware, Withdrawable {
     //@dev canvas has been sold, and has the owner
     uint8 public constant STATE_OWNED = 2;
 
-    uint8 public constant WIDTH = 5;
-    uint8 public constant HEIGHT = 5;
-    uint32 public constant PIXEL_COUNT = 25; //WIDTH * HEIGHT doesn't work for some reason
+    uint8 public constant WIDTH = 48;
+    uint8 public constant HEIGHT = 48;
+    uint32 public constant PIXEL_COUNT = 2304; //WIDTH * HEIGHT doesn't work for some reason
 
     uint32 public constant MAX_CANVAS_COUNT = 1000;
     uint8 public constant MAX_ACTIVE_CANVAS = 12;

--- a/contracts/CanvasState.sol
+++ b/contracts/CanvasState.sol
@@ -1,0 +1,124 @@
+pragma solidity ^0.4.0;
+
+import "./CanvasFactory.sol";
+
+/**
+* @notice   Useful methods to manage canvas' state.
+*/
+contract CanvasState is CanvasFactory {
+
+    modifier stateBidding(uint32 _canvasId) {
+        require(getCanvasState(_canvasId) == STATE_INITIAL_BIDDING);
+        _;
+    }
+
+    modifier stateOwned(uint32 _canvasId) {
+        require(getCanvasState(_canvasId) == STATE_OWNED);
+        _;
+    }
+
+    /**
+    * Ensures that canvas's saved state is STATE_OWNED.
+    *
+    * Because initial bidding is based on current time, we had to find a way to
+    * trigger saving new canvas state. Every transaction (not a call) that
+    * requires state owned should use it modifier as a last one.
+    *
+    * Thank's to that, we can make sure, that canvas state gets updated.
+    */
+    modifier forceOwned(uint32 _canvasId) {
+        Canvas storage canvas = _getCanvas(_canvasId);
+        if (canvas.state != STATE_OWNED) {
+            canvas.state = STATE_OWNED;
+        }
+        _;
+    }
+
+    /**
+    * @notice   Returns current canvas state.
+    */
+    function getCanvasState(uint32 _canvasId) public view returns (uint8) {
+        Canvas storage canvas = _getCanvas(_canvasId);
+        if (canvas.state != STATE_INITIAL_BIDDING) {
+            //if state is set to owned, or not finished
+            //it means it doesn't depend on current time -
+            //we don't have to double check
+            return canvas.state;
+        }
+
+        //state initial bidding - as that state depends on
+        //current time, we have to double check if initial bidding
+        //hasn't finish yet
+        uint finishTime = canvas.initialBiddingFinishTime;
+        if (finishTime == 0 || finishTime > getTime()) {
+            return STATE_INITIAL_BIDDING;
+
+        } else {
+            return STATE_OWNED;
+        }
+    }
+
+    /**
+    * @notice   Returns all canvas' id for a given state.
+    */
+    function getCanvasByState(uint8 _state) external view returns (uint32[]) {
+        uint size;
+        if (_state == STATE_NOT_FINISHED) {
+            size = activeCanvasCount;
+        } else {
+            size = getCanvasCount() - activeCanvasCount;
+        }
+
+        uint32[] memory result = new uint32[](size);
+        uint currentIndex = 0;
+
+        for (uint32 i = 0; i < canvases.length; i++) {
+            if (getCanvasState(i) == _state) {
+                result[currentIndex] = i;
+                currentIndex++;
+            }
+        }
+
+        return _slice(result, 0, currentIndex);
+    }
+
+    /**
+    * Sets canvas name. Only for the owner of the canvas. Name can be an empty
+    * string which is the same as lack of the name.
+    */
+    function setCanvasName(uint32 _canvasId, string _name) external
+    stateOwned(_canvasId)
+    forceOwned(_canvasId)
+    {
+        bytes memory _strBytes = bytes(_name);
+        require(_strBytes.length <= MAX_CANVAS_NAME_LENGTH);
+
+        Canvas storage _canvas = _getCanvas(_canvasId);
+        require(msg.sender == _canvas.owner);
+
+        _canvas.name = _name;
+        emit CanvasNameSet(_canvasId, _name);
+    }
+
+    /**
+    * @dev  Slices array from start (inclusive) to end (exclusive).
+    *       Doesn't modify input array.
+    */
+    function _slice(uint32[] memory _array, uint _start, uint _end) internal pure returns (uint32[]) {
+        require(_start <= _end);
+
+        if (_start == 0 && _end == _array.length) {
+            return _array;
+        }
+
+        uint size = _end - _start;
+        uint32[] memory sliced = new uint32[](size);
+
+        for (uint i = 0; i < size; i++) {
+            sliced[i] = _array[i + _start];
+        }
+
+        return sliced;
+    }
+
+}

--- a/contracts/RewardableCanvas.sol
+++ b/contracts/RewardableCanvas.sol
@@ -1,0 +1,254 @@
+pragma solidity 0.4.24;
+
+import "./CanvasState.sol";
+
+/**
+* @notice   Keeps track of all rewards and commissions.
+*           Commission - fee that we charge for using CryptoCanvas.
+*           Reward - painters cut.
+*/
+contract RewardableCanvas is CanvasState {
+
+    /**
+    * As it's hard to operate on floating numbers, each fee will be calculated like this:
+    * PRICE * COMMISSION / COMMISSION_DIVIDER. It's impossible to keep float number here.
+    *
+    * ufixed COMMISSION = 0.039; may seem useful, but it's not possible to multiply ufixed * uint.
+    */
+    uint public constant COMMISSION = 39;
+    uint public constant TRADE_REWARD = 61;
+    uint public constant PERCENT_DIVIDER = 1000;
+
+    event RewardAddedToWithdrawals(uint32 indexed canvasId, address indexed toAddress, uint amount);
+    event CommissionAddedToWithdrawals(uint32 indexed canvasId, uint amount);
+    event FeesUpdated(uint32 indexed canvasId, uint totalCommissions, uint totalReward);
+
+    mapping(uint32 => FeeHistory) private canvasToFeeHistory;
+
+    function addCommissionToPendingWithdrawals(uint32 _canvasId)
+    public
+    onlyOwner
+    stateOwned(_canvasId)
+    forceOwned(_canvasId) {
+        FeeHistory storage _history = _getOrCreateFeeHistory(_canvasId);
+        uint _toWithdraw = calculateCommissionToWithdraw(_canvasId);
+        uint _lastIndex = _history.commissionCumulative.length - 1;
+
+        _history.paidCommissionIndex = _lastIndex;
+        addPendingWithdrawal(owner, _toWithdraw);
+
+        emit CommissionAddedToWithdrawals(_canvasId, _toWithdraw);
+    }
+
+    function addRewardToPendingWithdrawals(uint32 _canvasId)
+    public
+    stateOwned(_canvasId)
+    forceOwned(_canvasId) {
+        FeeHistory storage _history = _getOrCreateFeeHistory(_canvasId);
+        uint _toWithdraw = calculateRewardToWithdraw(_canvasId, msg.sender);
+        uint _lastIndex = _history.rewardsCumulative.length - 1;
+
+        _history.addressToPaidRewardIndex[msg.sender] = _lastIndex;
+        addPendingWithdrawal(msg.sender, _toWithdraw);
+
+        emit RewardAddedToWithdrawals(_canvasId, msg.sender, _toWithdraw);
+    }
+
+    function calculateCommissionToWithdraw(uint32 _canvasId)
+    public
+    view
+    stateOwned(_canvasId)
+    returns (uint)
+    {
+        require(_canvasId < canvases.length);
+        FeeHistory storage _history = canvasToFeeHistory[_canvasId];
+        uint _lastIndex = _history.commissionCumulative.length - 1;
+        uint _lastPaidIndex = _history.paidCommissionIndex;
+
+        if (_lastIndex < 0) {
+            //means that FeeHistory hasn't been created yet
+            return 0;
+        }
+
+        uint _commissionSum = _history.commissionCumulative[_lastIndex];
+        uint _lastWithdrawn = _history.commissionCumulative[_lastPaidIndex];
+
+        uint _toWithdraw = _commissionSum - _lastWithdrawn;
+        require(_toWithdraw <= _commissionSum);
+
+        return _toWithdraw;
+    }
+
+    function calculateRewardToWithdraw(uint32 _canvasId, address _address)
+    public
+    view
+    stateOwned(_canvasId)
+    returns (uint)
+    {
+        require(_canvasId < canvases.length);
+        FeeHistory storage _history = canvasToFeeHistory[_canvasId];
+        uint _lastIndex = _history.rewardsCumulative.length - 1;
+        uint _lastPaidIndex = _history.addressToPaidRewardIndex[_address];
+
+        if (_lastIndex < 0) {
+            //means that FeeHistory hasn't been created yet
+            return 0;
+        }
+
+        uint _rewardsSum = _history.rewardsCumulative[_lastIndex];
+        uint _lastWithdrawn = _history.rewardsCumulative[_lastPaidIndex];
+        uint _pixelsOwned = getPaintedPixelsCountByAddress(_address, _canvasId);
+
+        // Our data structure guarantees that _commissionSum is greater or equal to _lastWithdrawn
+        uint _toWithdraw = ((_rewardsSum - _lastWithdrawn) / PIXEL_COUNT) * _pixelsOwned;
+
+        return _toWithdraw;
+    }
+
+    /**
+    * @notice   Calculates how the initial bidding money will be split.
+    *
+    * @return  Commission and sum of all painter rewards.
+    */
+    function splitBid(uint _amount) public pure returns (
+        uint commission,
+        uint paintersRewards
+    ){
+        uint _rewardPerPixel = ((_amount - _calculatePercent(_amount, COMMISSION))) / PIXEL_COUNT;
+        // Rewards is divisible by PIXEL_COUNT
+        uint _rewards = _rewardPerPixel * PIXEL_COUNT;
+
+        return (_amount - _rewards, _rewards);
+    }
+
+    /**
+    * @notice   Calculates how the money from selling canvas will be split.
+    *
+    * @return  Commission, sum of painters' rewards and a seller's profit.
+    */
+    function splitTrade(uint _amount) public pure returns (
+        uint commission,
+        uint paintersRewards,
+        uint sellerProfit
+    ){
+        uint _commission = _calculatePercent(_amount, COMMISSION);
+
+        // We make sure that painters reward is divisible by PIXEL_COUNT.
+        // It is important to split reward across all the painters equally.
+        uint _rewardPerPixel = _calculatePercent(_amount, TRADE_REWARD) / PIXEL_COUNT;
+        uint _paintersReward = _rewardPerPixel * PIXEL_COUNT;
+
+        uint _sellerProfit = _amount - _commission - _paintersReward;
+
+        //check for the underflow
+        require(_sellerProfit < _amount);
+
+        return (_commission, _paintersReward, _sellerProfit);
+    }
+
+    /**
+    * @notice   Adds a bid to fee history. Doesn't perform any checks if the bid is valid!
+    * @return  Returns how the bid was split. Same value as _splitBid function.
+    */
+    function _registerBid(uint32 _canvasId, uint _amount) internal stateBidding(_canvasId) returns (
+        uint commission,
+        uint paintersRewards
+    ){
+        uint _commission;
+        uint _rewards;
+        (_commission, _rewards) = splitBid(_amount);
+
+        FeeHistory storage _history = _getOrCreateFeeHistory(_canvasId);
+        // We have to save the difference between new bid and a previous one.
+        // Because we save data as cumulative sum, it's enough to save
+        // only the new value.
+
+        _history.commissionCumulative.push(_commission);
+        _history.rewardsCumulative.push(_rewards);
+
+        return (_commission, _rewards);
+    }
+
+    /**
+    * @notice   Adds a bid to fee history. Doesn't perform any checks if the bid is valid!
+    * @return  Returns how the trade ethers were split. Same value as splitTrade function.
+    */
+    function _registerTrade(uint32 _canvasId, uint _amount)
+    internal
+    stateOwned(_canvasId)
+    forceOwned(_canvasId)
+    returns (
+        uint commission,
+        uint paintersRewards,
+        uint sellerProfit
+    ){
+        uint _commission;
+        uint _rewards;
+        uint _sellerProfit;
+        (_commission, _rewards, _sellerProfit) = splitTrade(_amount);
+
+        FeeHistory storage _history = _getOrCreateFeeHistory(_canvasId);
+        _pushCumulative(_history.commissionCumulative, _commission);
+        _pushCumulative(_history.rewardsCumulative, _rewards);
+
+        return (_commission, _rewards, _sellerProfit);
+    }
+
+    /**
+    * @notice   Gets a fee history of a canvas. Creates a new fee history
+    *           entry if necessary.
+    */
+    function _getOrCreateFeeHistory(uint32 _canvasId) private returns (FeeHistory storage) {
+        require(_canvasId < canvases.length);
+        FeeHistory storage _history = canvasToFeeHistory[_canvasId];
+        if (_history.commissionCumulative.length == 0) {
+            //It means that there is no added entrance yet
+            //Init cumulative sums with 0, it will make our math easier
+            canvasToFeeHistory[_canvasId] = FeeHistory(new uint[](1), new uint[](1), 0);
+            _history = canvasToFeeHistory[_canvasId];
+
+        }
+
+        return _history;
+    }
+
+    function _pushCumulative(uint[] storage _array, uint _value) private returns (uint) {
+        uint _lastValue = _array[_array.length - 1];
+        uint _newValue = _lastValue + _value;
+        //overflow protection
+        require(_newValue >= _lastValue);
+        return _array.push(_newValue);
+    }
+
+    /**
+    * @param    _percent - percent value mapped to scale [0-1000]
+    */
+    function _calculatePercent(uint _amount, uint _percent) private pure returns (uint) {
+        return (_amount * _percent) / PERCENT_DIVIDER;
+    }
+
+    struct FeeHistory {
+
+        /**
+        * @notice   Cumulative sum of all charged commissions.
+        */
+        uint[] commissionCumulative;
+
+        /**
+        * @notice   Cumulative sum of all charged rewards.
+        */
+        uint[] rewardsCumulative;
+
+        /**
+        * Index of last paid commission (from commissionCumulative array)
+        */
+        uint paidCommissionIndex;
+
+        /**
+        * Mapping showing what rewards has been already paid.
+        */
+        mapping(address => uint) addressToPaidRewardIndex;
+
+    }
+
+}

--- a/contracts/RewardableCanvas.sol
+++ b/contracts/RewardableCanvas.sol
@@ -105,6 +105,32 @@ contract RewardableCanvas is CanvasState {
         return _toWithdraw;
     }
 
+    function getTotalCommission(uint32 _canvasId) external view returns (uint) {
+        require(_canvasId < canvases.length);
+        FeeHistory storage _history = canvasToFeeHistory[_canvasId];
+        uint _lastIndex = _history.commissionCumulative.length - 1;
+
+        if (_lastIndex < 0) {
+            //means that FeeHistory hasn't been created yet
+            return 0;
+        }
+
+        return _history.commissionCumulative[_lastIndex];
+    }
+
+    function getTotalRewards(uint32 _canvasId) external view returns (uint) {
+        require(_canvasId < canvases.length);
+        FeeHistory storage _history = canvasToFeeHistory[_canvasId];
+        uint _lastIndex = _history.rewardsCumulative.length - 1;
+
+        if (_lastIndex < 0) {
+            //means that FeeHistory hasn't been created yet
+            return 0;
+        }
+
+        return _history.rewardsCumulative[_lastIndex];
+    }
+
     /**
     * @notice   Calculates how the initial bidding money will be split.
     *

--- a/contracts/RewardableCanvas.sol
+++ b/contracts/RewardableCanvas.sol
@@ -170,8 +170,8 @@ contract RewardableCanvas is CanvasState {
     }
 
     /**
-    * @notice   Returns total amount of commission that has been already
-    *           paid (added to pending withdrawals).
+    * @notice   Returns total amount of rewards that has been already
+    *           paid (added to pending withdrawals) by a given address.
     */
     function getRewardsWithdrawn(uint32 _canvasId, address _address) external view returns (uint) {
         require(_canvasId < canvases.length);

--- a/contracts/RewardableCanvas.sol
+++ b/contracts/RewardableCanvas.sol
@@ -118,6 +118,14 @@ contract RewardableCanvas is CanvasState {
         return _history.commissionCumulative[_lastIndex];
     }
 
+    function getCommissionWithdrawn(uint32 _canvasId) external view returns (uint) {
+        require(_canvasId < canvases.length);
+        FeeHistory storage _history = canvasToFeeHistory[_canvasId];
+        uint _index = _history.paidCommissionIndex;
+
+        return _history.commissionCumulative[_index];
+    }
+
     function getTotalRewards(uint32 _canvasId) external view returns (uint) {
         require(_canvasId < canvases.length);
         FeeHistory storage _history = canvasToFeeHistory[_canvasId];
@@ -129,6 +137,15 @@ contract RewardableCanvas is CanvasState {
         }
 
         return _history.rewardsCumulative[_lastIndex];
+    }
+
+    function getRewardsWithdrawn(uint32 _canvasId, address _address) external view returns (uint) {
+        require(_canvasId < canvases.length);
+        FeeHistory storage _history = canvasToFeeHistory[_canvasId];
+        uint _index = _history.addressToPaidRewardIndex[_address];
+        uint _pixelsOwned = getPaintedPixelsCountByAddress(_address, _canvasId);
+
+        return _history.rewardsCumulative[_index] / _pixelsOwned;
     }
 
     /**

--- a/contracts/RewardableCanvas.sol
+++ b/contracts/RewardableCanvas.sol
@@ -179,7 +179,11 @@ contract RewardableCanvas is CanvasState {
         uint _index = _history.addressToPaidRewardIndex[_address];
         uint _pixelsOwned = getPaintedPixelsCountByAddress(_address, _canvasId);
 
-        return _history.rewardsCumulative[_index] / _pixelsOwned;
+        if (_history.rewardsCumulative.length == 0 || _index == 0) {
+            return 0;
+        }
+
+        return (_history.rewardsCumulative[_index] / PIXEL_COUNT) * _pixelsOwned;
     }
 
     /**

--- a/test/TestableArtWrapper.js
+++ b/test/TestableArtWrapper.js
@@ -104,10 +104,15 @@ export class TestableArtWrapper {
     calculateCommissionToWithdraw = async (canvasId) => await this.instance.calculateCommissionToWithdraw(canvasId);
 
     /**
-     * @returns {Promise<BigNumber>}
+     * @returns {Promise<{reward: BigNumber, pixelsOwned: number}>}
      */
-    calculateRewardToWithdraw = async (canvasId, address) =>
-        await this.instance.calculateRewardToWithdraw(canvasId, address);
+    calculateRewardToWithdraw = async (canvasId, address) => {
+        let result = await this.instance.calculateRewardToWithdraw(canvasId, address);
+        return {
+            reward: result[0],
+            pixelsOwned: parseInt(result[1])
+        };
+    };
 
     /**
      * @returns {Promise<BigNumber>}

--- a/test/TestableArtWrapper.js
+++ b/test/TestableArtWrapper.js
@@ -63,6 +63,9 @@ export class TestableArtWrapper {
         return bitmap.map(it => parseInt(it));
     };
 
+    /**
+     * @returns {Promise<number>}
+     */
     getPaintedPixelsCountByAddress = async (address, canvasId) => parseInt(await this.instance.getPaintedPixelsCountByAddress(address, canvasId));
 
     getCanvasPaintedPixelsCount = async (canvasId) => parseInt(await this.instance.getCanvasPaintedPixelsCount(canvasId));
@@ -95,22 +98,59 @@ export class TestableArtWrapper {
     addRewardToPendingWithdrawals = async (canvasId, options = {}) =>
         await this.instance.addRewardToPendingWithdrawals(canvasId, options);
 
+    /**
+     * @returns {Promise<BigNumber>}
+     */
     calculateCommissionToWithdraw = async (canvasId) => await this.instance.calculateCommissionToWithdraw(canvasId);
 
+    /**
+     * @returns {Promise<BigNumber>}
+     */
     calculateRewardToWithdraw = async (canvasId, address) =>
         await this.instance.calculateRewardToWithdraw(canvasId, address);
 
+    /**
+     * @returns {Promise<BigNumber>}
+     */
     getTotalCommission = async (canvasId) => await this.instance.getTotalCommission(canvasId);
 
+    /**
+     * @returns {Promise<BigNumber>}
+     */
     getCommissionWithdrawn = async (canvasId) => await this.instance.getCommissionWithdrawn(canvasId);
 
+    /**
+     * @returns {Promise<BigNumber>}
+     */
     getTotalRewards = async (canvasId) => await this.instance.getTotalRewards(canvasId);
 
+    /**
+     * @returns {Promise<BigNumber>}
+     */
     getRewardsWithdrawn = async (canvasId, address) => await this.instance.getRewardsWithdrawn(canvasId, address);
 
-    splitBid = async (amount) => await this.instance.splitBid(amount);
+    /**
+     * @returns {Promise<{commission: BigNumber, paintersRewards: BigNumber}>}
+     */
+    splitBid = async (amount) => {
+        let result = await this.instance.splitBid(amount);
+        return {
+            commission: result[0],
+            paintersRewards: result[1]
+        };
+    };
 
-    splitTrade = async (amount) => await this.instance.splitTrade(amount);
+    /**
+     * @returns {Promise<{commission: BigNumber, paintersRewards: BigNumber, sellerProfit: BigNumber}>}
+     */
+    splitTrade = async (amount) => {
+        let result = await this.instance.splitTrade(amount);
+        return {
+            commission: result[0],
+            paintersRewards: result[1],
+            sellerProfit: result[2]
+        };
+    };
 
 
     //===
@@ -155,6 +195,9 @@ export class TestableArtWrapper {
 
     acceptBuyOffer = async (canvasId, minPrice, options = {}) => await this.instance.acceptBuyOffer(canvasId, minPrice, options);
 
+    /**
+     * @returns {Promise<{hasOffer: boolean, buyer: string, amount: number}>}
+     */
     getCurrentBuyOffer = async (canvasId) => {
         const result = await this.instance.getCurrentBuyOffer(canvasId);
         return {

--- a/test/TestableArtWrapper.js
+++ b/test/TestableArtWrapper.js
@@ -87,26 +87,33 @@ export class TestableArtWrapper {
 
     balanceOf = async (address) => parseInt(await this.instance.balanceOf(address));
 
-    calculateCommission = async (canvasId) => {
-        const result = await this.instance.calculateCommission(canvasId);
-        return {
-            commission: result[0],
-            isPaid: result[1]
-        }
-    };
+    //RewardableCanvas
 
-    calculateReward = async (canvasId, address) => {
-        const result = await this.instance.calculateReward(canvasId, address);
-        return {
-            pixelCount: parseInt(result[0]),
-            reward: result[1],
-            isPaid: result[2]
-        }
-    };
+    addCommissionToPendingWithdrawals = async (canvasId, options = {}) =>
+        await this.instance.addCommissionToPendingWithdrawals(canvasId, options);
 
-    addRewardToPendingWithdrawals = async (canvasId, options = {}) => await this.instance.addRewardToPendingWithdrawals(canvasId, options);
+    addRewardToPendingWithdrawals = async (canvasId, options = {}) =>
+        await this.instance.addRewardToPendingWithdrawals(canvasId, options);
 
-    addCommissionToPendingWithdrawals = async (canvasId, options = {}) => await this.instance.addCommissionToPendingWithdrawals(canvasId, options);
+    calculateCommissionToWithdraw = async (canvasId) => await this.instance.calculateCommissionToWithdraw(canvasId);
+
+    calculateRewardToWithdraw = async (canvasId, address) =>
+        await this.instance.calculateRewardToWithdraw(canvasId, address);
+
+    getTotalCommission = async (canvasId) => await this.instance.getTotalCommission(canvasId);
+
+    getCommissionWithdrawn = async (canvasId) => await this.instance.getCommissionWithdrawn(canvasId);
+
+    getTotalRewards = async (canvasId) => await this.instance.getTotalRewards(canvasId);
+
+    getRewardsWithdrawn = async (canvasId, address) => await this.instance.getRewardsWithdrawn(canvasId, address);
+
+    splitBid = async (amount) => await this.instance.splitBid(amount);
+
+    splitTrade = async (amount) => await this.instance.splitTrade(amount);
+
+
+    //===
 
     getCanvasInfo = async (canvasId) => {
         const result = await this.instance.getCanvasInfo(canvasId);

--- a/test/biddingTests.js
+++ b/test/biddingTests.js
@@ -1,5 +1,5 @@
 import {TestableArtWrapper} from "./TestableArtWrapper";
-import {checkBalanceConsistency, splitMoney} from "./utility";
+import {checkBalanceConsistency, checkCommissionsIntegrity, checkRewardsIntegrity, splitMoney} from "./utility";
 
 const BigNumber = require('bignumber.js');
 
@@ -38,6 +38,8 @@ contract('Initial bidding suite', async (accounts) => {
     afterEach(async () => {
         const instance = new TestableArtWrapper(await TestableArt.deployed());
         await checkBalanceConsistency(instance, accounts);
+        await checkCommissionsIntegrity(instance);
+        await checkRewardsIntegrity(instance, accounts);
     });
 
     it("should fail to return state of not existing canvas", async () => {

--- a/test/biddingTests.js
+++ b/test/biddingTests.js
@@ -237,7 +237,7 @@ contract('Initial bidding suite', async (accounts) => {
 
             const reward = await instance.calculateRewardToWithdraw(0, account);
 
-            desiredReward.eq(reward).should.be.true;
+            desiredReward.eq(reward.reward).should.be.true;
         }
     });
 
@@ -247,7 +247,7 @@ contract('Initial bidding suite', async (accounts) => {
         let account = accounts[9];
         const reward = await instance.calculateRewardToWithdraw(0, account);
 
-        reward.eq(0).should.be.true;
+        reward.reward.eq(0).should.be.true;
         return instance.addRewardToPendingWithdrawals(0, {from: account}).should.be.rejected;
     });
 
@@ -256,7 +256,7 @@ contract('Initial bidding suite', async (accounts) => {
 
         for (let i = 0; i < ACCOUNT_PIXELS.length; i++) {
             const account = accounts[i];
-            let reward = await instance.calculateRewardToWithdraw(0, account);
+            let reward = (await instance.calculateRewardToWithdraw(0, account)).reward;
 
             const pending = await instance.getPendingWithdrawal(account);
 
@@ -271,7 +271,7 @@ contract('Initial bidding suite', async (accounts) => {
             const withdrawn = await instance.getRewardsWithdrawn(0, account);
             withdrawn.eq(reward).should.be.true;
 
-            reward = await instance.calculateRewardToWithdraw(0, account);
+            reward = (await instance.calculateRewardToWithdraw(0, account)).reward;
             reward.eq(0).should.be.true;
         }
     });

--- a/test/tradingTests.js
+++ b/test/tradingTests.js
@@ -1,5 +1,5 @@
 import {TestableArtWrapper} from "./TestableArtWrapper";
-import {checkBalanceConsistency} from "./utility";
+import {checkBalanceConsistency, checkCommissionsIntegrity, checkRewardsIntegrity} from "./utility";
 
 const chai = require('chai');
 chai.use(require('chai-as-promised')).should();
@@ -33,6 +33,8 @@ contract('Canvas trading suite', async (accounts) => {
     afterEach(async () => {
         const instance = new TestableArtWrapper(await TestableArt.deployed());
         await checkBalanceConsistency(instance, accounts);
+        await checkCommissionsIntegrity(instance);
+        await checkRewardsIntegrity(instance, accounts);
     });
 
     /**

--- a/test/tradingTests.js
+++ b/test/tradingTests.js
@@ -22,6 +22,9 @@ const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 const eth = new BigNumber("100000000000000000");
 
+const ACCOUNT_PIXELS = [200, 275, 225, 250, 175, 270, 250, 284, 375];
+// const ACCOUNT_PIXELS = [1, 2, 5, 2, 3, 4, 1, 2, 5];
+
 /**
  * All tests that involve trading will calculate expected fees. It has to verified
  * at the end of the test suite.
@@ -114,11 +117,21 @@ contract('Canvas trading suite', async (accounts) => {
      */
     it('should fill the canvas', async () => {
         const instance = new TestableArtWrapper(await TestableArt.deployed());
-        await instance.fillWholeCanvas(0); //we don't really care here who is painting
-        // await instance.fillCanvas(0, 0, 25);
+
+        const pixelIndices = [0];
+        ACCOUNT_PIXELS.reduce(function (a, b, i) {
+            return pixelIndices[i + 1] = a + b;
+        }, 0);
+
+        for (let i = 1; i < pixelIndices.length; i++) {
+            await instance.fillCanvas(0, pixelIndices[i - 1], pixelIndices[i], i, {from: accounts[i - 1]});
+        }
 
         const state = await instance.getCanvasState(0);
+        const bidding = await instance.getCanvasByState(1);
+
         state.should.be.eq(STATE_INITIAL_BIDDING);
+        bidding.should.be.equalTo([0]);
     });
 
     it("should not allow to buy when canvas is in initial bidding", async () => {

--- a/test/tradingTests.js
+++ b/test/tradingTests.js
@@ -30,7 +30,7 @@ let owner = '0x0';
 
 contract('Canvas trading suite', async (accounts) => {
 
-    beforeEach(async () => {
+    afterEach(async () => {
         const instance = new TestableArtWrapper(await TestableArt.deployed());
         await checkBalanceConsistency(instance, accounts);
     });

--- a/test/utility.js
+++ b/test/utility.js
@@ -23,32 +23,43 @@ export function generateArray(from, to) {
 }
 
 /**
- * Splits money. Calculates reward per pixel, total reward and a commission.
- * Note that total commission can be a bit higher that commission * amount,
- * because of integer division remainder when calculating pixel price.
- *
- * @param {BigNumber} amount - amount to split
- * @param {Number} commission - float number, greater than 0.0, smaller than 1.0
- * @param {Number} pixelCount - pixel count. Integer number
- *
- * @returns {{cut: BigNumber, pricePerPixel: BigNumber, rewards: BigNumber}}
+ * @param {BigNumber} amount
+ * @param {number} pixelCount
  */
-export function splitMoney(amount, commission, pixelCount) {
-    pixelCount = Math.floor(pixelCount);
-    amount = new BigNumber(amount);
+export function splitBid(amount, pixelCount) {
+    const fee = amount.times(39)
+        .dividedBy(1000);
 
-    const rewardPercent = new BigNumber(1 - commission);
-    const pricePerPixel = amount.multipliedBy(rewardPercent)
-        .dividedBy(pixelCount)
-        .integerValue(BigNumber.BigNumber.ROUND_FLOOR);
+    const rewardPerPixel = amount.minus(fee)
+        .dividedBy(pixelCount);
 
-    const rewardsSum = pricePerPixel.multipliedBy(pixelCount);
-    const cut = amount.minus(rewardsSum);
+    const rewards = rewardPerPixel.times(pixelCount);
 
     return {
-        cut: cut,
-        pricePerPixel: pricePerPixel,
-        rewards: rewardsSum
+        commission: amount.minus(rewards),
+        paintersRewards: rewards
+    }
+}
+
+/**
+ * @param {BigNumber} amount
+ * @param {number} pixelCount
+ */
+export function splitTrade(amount, pixelCount) {
+    const commission = amount.times(39)
+        .dividedBy(1000);
+
+    const rewardPerPixel = amount.times(61)
+        .dividedBy(1000)
+        .dividedBy(pixelCount);
+
+    const rewards = rewardPerPixel.times(pixelCount);
+    const sellerProfit = amount.minus(rewards).minus(commission);
+
+    return {
+        commission: commission,
+        paintersRewards: rewards,
+        sellerProfit: sellerProfit
     }
 }
 

--- a/test/utility.js
+++ b/test/utility.js
@@ -93,10 +93,10 @@ export async function checkCommissionsIntegrity(instance) {
 
             const sum = toWithdraw.plus(withdrawnCommission);
             if (!sum.eq(totalCommission)) {
-                assert.fail(null, null, `Failed checking commission integrity for canvas ${i}.` +
-                    `\tCommission to withdraw: ${toWithdraw}` +
-                    `\tWithdrawn commission  : ${withdrawnCommission}` +
-                    `\tTotal commission      : ${totalCommission}`);
+                assert.fail(null, null, `Failed checking commission integrity for canvas ${i}.\n` +
+                    `\tCommission to withdraw: ${toWithdraw}\n` +
+                    `\tWithdrawn commission  : ${withdrawnCommission}\n` +
+                    `\tTotal commission      : ${totalCommission}\n`);
             }
         }
     }
@@ -108,6 +108,7 @@ export async function checkCommissionsIntegrity(instance) {
  */
 export async function checkRewardsIntegrity(instance, accounts) {
     const canvasCount = await instance.canvasCount();
+    const pixelCount = await instance.PIXEL_COUNT();
 
     for (let i = 0; i < canvasCount; i++) {
         const state = await instance.getCanvasState(i);
@@ -127,20 +128,22 @@ export async function checkRewardsIntegrity(instance, accounts) {
             paid = paid.plus(rewardPaid);
             toWithdraw = toWithdraw.plus(toReward);
 
-            const expectedReward = totalRewards.dividedBy(pixelsOwned);
+            const expectedReward = totalRewards.dividedBy(pixelCount).times(pixelsOwned);
             if (!rewardPaid.plus(toReward).eq(expectedReward)) {
-                assert.fail(null, null, `Failed checking rewards integrity for canvas ${i}, account: ${accounts[j]}` +
-                    `\tRewards paid           : ${rewardPaid}` +
-                    `\tTo reward              : ${toReward}` +
-                    `\tExpected total reward  : ${expectedReward}`);
+                assert.fail(null, null, `Failed checking rewards integrity for canvas ${i}, account[${j}]: ${accounts[j]}\n` +
+                    `\tRewards paid     : ${rewardPaid}\n` +
+                    `\tTo reward        : ${toReward}\n` +
+                    `\tOwned pixels:    : ${pixelsOwned}\n` +
+                    `\tTotal rewards:   : ${totalRewards}\n` +
+                    `\tExpected reward  : ${expectedReward}\n`);
             }
         }
 
         if (!paid.plus(toWithdraw).eq(totalRewards)) {
-            assert.fail(null, null, `Failed checking rewards integrity for canvas ${i}.` +
-                `\tTotal paid    : ${paid}` +
-                `\tTotal to pay  : ${toWithdraw}` +
-                `\tTotal rewards : ${totalRewards}`);
+            assert.fail(null, null, `Failed checking rewards integrity for canvas ${i}.\n` +
+                `\tTotal paid    : ${paid}\n` +
+                `\tTotal to pay  : ${toWithdraw}\n` +
+                `\tTotal rewards : ${totalRewards}\n`);
         }
     }
 }

--- a/test/utility.js
+++ b/test/utility.js
@@ -133,7 +133,7 @@ export async function checkRewardsIntegrity(instance, accounts) {
 
         for (let j = 0; j < accounts.length; j++) {
             const rewardPaid = await instance.getRewardsWithdrawn(i, accounts[j]);
-            const toReward = await instance.calculateRewardToWithdraw(i, accounts[j]);
+            const toReward = (await instance.calculateRewardToWithdraw(i, accounts[j])).reward;
             const pixelsOwned = await instance.getPaintedPixelsCountByAddress(accounts[j], i);
 
             paid = paid.plus(rewardPaid);
@@ -182,7 +182,7 @@ async function calculateRewards(instance, accounts) {
             const state = await instance.getCanvasState(j);
 
             if (state === STATE_OWNED) {
-                const reward = await instance.calculateRewardToWithdraw(j, account);
+                const reward = (await instance.calculateRewardToWithdraw(j, account)).reward;
                 rewards = rewards.plus(reward);
             }
         }

--- a/test/utility.js
+++ b/test/utility.js
@@ -28,10 +28,10 @@ export function generateArray(from, to) {
  */
 export function splitBid(amount, pixelCount) {
     const fee = amount.times(39)
-        .dividedBy(1000);
+        .dividedToIntegerBy(1000);
 
     const rewardPerPixel = amount.minus(fee)
-        .dividedBy(pixelCount);
+        .dividedToIntegerBy(pixelCount);
 
     const rewards = rewardPerPixel.times(pixelCount);
 
@@ -47,11 +47,11 @@ export function splitBid(amount, pixelCount) {
  */
 export function splitTrade(amount, pixelCount) {
     const commission = amount.times(39)
-        .dividedBy(1000);
+        .dividedToIntegerBy(1000);
 
     const rewardPerPixel = amount.times(61)
-        .dividedBy(1000)
-        .dividedBy(pixelCount);
+        .dividedToIntegerBy(1000)
+        .dividedToIntegerBy(pixelCount);
 
     const rewards = rewardPerPixel.times(pixelCount);
     const sellerProfit = amount.minus(rewards).minus(commission);


### PR DESCRIPTION
Closes #10. Painters get 6.1% after each trade. Rewards/commission system redesigned. 

API to handle rewards/commissions (_look into `RewardableCanvas` code to get into details_): 
* `addCommissionToPendingWithdrawals(canvasId)` - adds commission to the owner's pending withdrawals 
* `addRewardToPendingWithdrawals(canvasId)` - adds all unpaid rewards of the caller to his pending withdrawals.
* `calculateCommissionToWithdraw(canvasId)` - calculates how much of commission there is to be paid.
* `calculateRewardToWithdraw(canvasId, addresss)` - calculates unpaid rewards of a given address. Returns amount to withdraw and amount of pixels owned.
* `getTotalCommission(canvasId)` - returns total amount of commission charged for a given canvas.
* `getCommissionWithdrawn(canvasId)` - Returns total amount of commission that has been already paid (added to pending withdrawals).
* `getTotalRewards(canvasId)` - returns all rewards charged for the given canvas.
* `getRewardsWithdrawn(canvasId, address)` - Returns total amount of rewards that has been already paid (added to pending withdrawals) by a given address.
* `splitBid(amountInWei)` - calculates how the initial bidding money will be split. Returns commission and sum of all painter rewards.
* `splitTrade(amountInWei)` - calculates how the money from selling canvas will be split. Returns commission, sum of painters' rewards and a seller's profit.