### PR TITLE
Booking canvas only for the owner

### DIFF
--- a/contracts/CanvasFactory.sol
+++ b/contracts/CanvasFactory.sol
@@ -26,8 +26,6 @@ contract CanvasFactory is TimeAware, Withdrawable {
     uint8 public constant MAX_ACTIVE_CANVAS = 12;
     uint8 public constant MAX_CANVAS_NAME_LENGTH = 24;
 
-    uint public bookCanvasPrice = 0.1 ether;
-
     Canvas[] canvases;
     uint32 public activeCanvasCount = 0;
 
@@ -62,11 +60,8 @@ contract CanvasFactory is TimeAware, Withdrawable {
     /**
     * @notice   Similar to createCanvas(). Additionally, books it for a caller.
     */
-    function createAndBookCanvas() external payable returns (uint canvasId) {
-        require(msg.value >= bookCanvasPrice);
-
-        addPendingWithdrawal(owner, msg.value);
-        return _createCanvasInternal(msg.sender);
+    function createAndBookCanvas(address _bookFor) external onlyOwner returns (uint canvasId) {
+        return _createCanvasInternal(_bookFor);
     }
 
     /**
@@ -159,10 +154,6 @@ contract CanvasFactory is TimeAware, Withdrawable {
     function getPaintedPixelsCountByAddress(address _address, uint32 _canvasId) public view returns (uint32) {
         Canvas storage canvas = _getCanvas(_canvasId);
         return canvas.addressToCount[_address];
-    }
-
-    function setBookPrice(uint _price) external onlyOwner {
-        bookCanvasPrice = _price;
     }
 
     function _isCanvasFinished(Canvas canvas) internal pure returns (bool) {

--- a/contracts/CanvasFactory.sol
+++ b/contracts/CanvasFactory.sol
@@ -58,7 +58,8 @@ contract CanvasFactory is TimeAware, Withdrawable {
     }
 
     /**
-    * @notice   Similar to createCanvas(). Additionally, books it for a caller.
+    * @notice   Similar to createCanvas(). Books it for given address. If address is 0x0 everybody will
+    *           be allowed to paint on a canvas.
     */
     function createAndBookCanvas(address _bookFor) external onlyOwner returns (uint canvasId) {
         return _createCanvasInternal(_bookFor);

--- a/test/TestableArtWrapper.js
+++ b/test/TestableArtWrapper.js
@@ -24,7 +24,7 @@ export class TestableArtWrapper {
 
     createCanvas = async () => await this.instance.createCanvas();
 
-    createAndBookCanvas = async (options = {}) => await this.instance.createAndBookCanvas(options);
+    createAndBookCanvas = async (address, options = {}) => await this.instance.createAndBookCanvas(address, options);
 
     setBookPrice = async (amount, options = {}) => await this.instance.setBookPrice(amount, options);
 

--- a/test/creationTests.js
+++ b/test/creationTests.js
@@ -71,18 +71,14 @@ contract('Simple canvas creation', async (accounts) => {
         active.should.be.equalTo([0, 1]);
     });
 
-    it('should disallow to book canvas for too small value', async function () {
+    it('should disallow to book canvas if not called by the owner', async function () {
         const instance = new TestableArtWrapper(await TestableArt.deployed());
-        const value = eth.multipliedBy(0.09).toNumber();
-
-        return instance.createAndBookCanvas({value}).should.be.rejected;
+        return instance.createAndBookCanvas(accounts[1], {from: accounts[1]}).should.be.rejected;
     });
 
     it('should allow to create and book canvas', async function () {
         const instance = new TestableArtWrapper(await TestableArt.deployed());
-        const value = eth.multipliedBy(0.1).toNumber();
-
-        await instance.createAndBookCanvas({from: accounts[1], value: value});
+        await instance.createAndBookCanvas(accounts[1], {from: accounts[0]});
         const info = await instance.getCanvasInfo(2);
 
         info.bookedFor.should.be.eq(accounts[1]);
@@ -104,27 +100,6 @@ contract('Simple canvas creation', async (accounts) => {
     it('should disallow to change booking price if not called by the owner', async function () {
         const instance = new TestableArtWrapper(await TestableArt.deployed());
         return instance.setBookPrice(eth.toNumber(), {from: accounts[1]}).should.be.rejected;
-    });
-
-    it('should change booking price', async function () {
-        const instance = new TestableArtWrapper(await TestableArt.deployed());
-        const oldValue = eth.multipliedBy(0.1).toNumber();
-        await instance.setBookPrice(eth.toNumber(), {from: accounts[0]});
-
-        const bookingPrice = await instance.bookCanvasPrice();
-        bookingPrice.eq(eth).should.be.true;
-
-        return instance.createAndBookCanvas({from: accounts[1], value: oldValue}).should.be.rejected;
-    });
-
-    it('should allow to create and book canvas after price change', async function () {
-        const instance = new TestableArtWrapper(await TestableArt.deployed());
-        const value = eth.toNumber();
-
-        await instance.createAndBookCanvas({from: accounts[5], value: value});
-        const info = await instance.getCanvasInfo(3);
-
-        info.bookedFor.should.be.eq(accounts[5]);
     });
 
     afterEach(async () => {

--- a/test/gasCostCalculator.js
+++ b/test/gasCostCalculator.js
@@ -122,13 +122,9 @@ contract('Contract gas calculator', async (accounts) => {
     it('calculate booking cost', async () => {
         const instance = new TestableArtWrapper(await TestableArt.deployed());
 
-        let transaction = await instance.createAndBookCanvas(accounts[1], {from: accounts[0]});
-        let cost = transaction.receipt.gasUsed;
+        const transaction = await instance.createAndBookCanvas(accounts[1], {from: accounts[0]});
+        const cost = transaction.receipt.gasUsed;
         gasCosts.push(['createAndBookCanvas()', cost]);
-
-        transaction = await instance.setBookPrice(eth.multipliedBy(2).toNumber(), {from: accounts[0]});
-        cost = transaction.receipt.gasUsed;
-        gasCosts.push(['setBookPrice()', cost]);
     });
 
 

--- a/test/gasCostCalculator.js
+++ b/test/gasCostCalculator.js
@@ -122,7 +122,7 @@ contract('Contract gas calculator', async (accounts) => {
     it('calculate booking cost', async () => {
         const instance = new TestableArtWrapper(await TestableArt.deployed());
 
-        let transaction = await instance.createAndBookCanvas({from: accounts[0], value: eth.toNumber()});
+        let transaction = await instance.createAndBookCanvas(accounts[1], {from: accounts[0]});
         let cost = transaction.receipt.gasUsed;
         gasCosts.push(['createAndBookCanvas()', cost]);
 


### PR DESCRIPTION
Closes #18. From now on, only the owner of the contract can create and book canvas for a specific address. 

Now function looks like this:
```Solidity
function createAndBookCanvas(address _bookFor) external onlyOwner returns (uint canvasId) {
        return _createCanvasInternal(_bookFor);
}
```