### PR TITLE
Changing booking for already existing canvases

### DIFF
--- a/contracts/CanvasFactory.sol
+++ b/contracts/CanvasFactory.sol
@@ -66,6 +66,14 @@ contract CanvasFactory is TimeAware, Withdrawable {
     }
 
     /**
+    * @notice   Changes canvas.bookFor variable. Only for the owner of the contract.
+    */
+    function bookCanvasFor(uint32 _canvasId, address _bookFor) external onlyOwner {
+        Canvas storage _canvas = _getCanvas(_canvasId);
+        _canvas.bookedFor = _bookFor;
+    }
+
+    /**
     * @notice   Sets pixel. Given canvas can't be yet finished.
     */
     function setPixel(uint32 _canvasId, uint32 _index, uint8 _color) external {

--- a/contracts/CanvasState.sol
+++ b/contracts/CanvasState.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.24;
 
 import "./CanvasFactory.sol";
 

--- a/test/TestableArtWrapper.js
+++ b/test/TestableArtWrapper.js
@@ -20,11 +20,11 @@ export class TestableArtWrapper {
 
     minimumBidAmount = async () => parseInt(await this.instance.minimumBidAmount());
 
-    bookCanvasPrice = async () => await this.instance.bookCanvasPrice();
-
     createCanvas = async () => await this.instance.createCanvas();
 
     createAndBookCanvas = async (address, options = {}) => await this.instance.createAndBookCanvas(address, options);
+
+    bookCanvasFor = async (canvasId, address, options = {}) => await this.instance.bookCanvasFor(canvasId, address, options);
 
     setBookPrice = async (amount, options = {}) => await this.instance.setBookPrice(amount, options);
 

--- a/test/creationTests.js
+++ b/test/creationTests.js
@@ -97,6 +97,34 @@ contract('Simple canvas creation', async (accounts) => {
         pixelAuthor.should.be.eq(accounts[1]);
     });
 
+    it('should disallow change booking if not called by the owner', async function () {
+        const instance = new TestableArtWrapper(await TestableArt.deployed());
+        return instance.bookCanvasFor(2, ZERO_ADDRESS, {from: accounts[1]}).should.be.rejected;
+    });
+
+    it('should change booking', async function () {
+        const instance = new TestableArtWrapper(await TestableArt.deployed());
+        await instance.bookCanvasFor(2, accounts[9], {from: accounts[0]});
+        const info = await instance.getCanvasInfo(2);
+
+        info.bookedFor.should.be.eq(accounts[9]);
+
+        await instance.setPixel(2, 22, 10, {from: accounts[9]});
+        return instance.setPixel(2, 23, 10, {from: accounts[2]}).should.be.rejected;
+    });
+
+    it('should clear booking', async function () {
+        const instance = new TestableArtWrapper(await TestableArt.deployed());
+        await instance.bookCanvasFor(2, ZERO_ADDRESS, {from: accounts[0]});
+        const info = await instance.getCanvasInfo(2);
+
+        info.bookedFor.should.be.eq(ZERO_ADDRESS);
+
+        await instance.setPixel(2, 12, 10, {from: accounts[9]});
+        await instance.setPixel(2, 13, 10, {from: accounts[2]});
+    });
+
+
     it('should disallow to change booking price if not called by the owner', async function () {
         const instance = new TestableArtWrapper(await TestableArt.deployed());
         return instance.setBookPrice(eth.toNumber(), {from: accounts[1]}).should.be.rejected;

--- a/test/gasCostCalculator.js
+++ b/test/gasCostCalculator.js
@@ -122,9 +122,13 @@ contract('Contract gas calculator', async (accounts) => {
     it('calculate booking cost', async () => {
         const instance = new TestableArtWrapper(await TestableArt.deployed());
 
-        const transaction = await instance.createAndBookCanvas(accounts[1], {from: accounts[0]});
-        const cost = transaction.receipt.gasUsed;
+        let transaction = await instance.createAndBookCanvas(accounts[1], {from: accounts[0]});
+        let cost = transaction.receipt.gasUsed;
         gasCosts.push(['createAndBookCanvas()', cost]);
+
+        transaction = await instance.bookCanvasFor(1, accounts[1], {from: accounts[0]});
+        cost = transaction.receipt.gasUsed;
+        gasCosts.push(['bookCanvasFor()', cost]);
     });
 
 


### PR DESCRIPTION
Now it's possible to change booking of the already created canvas. Only for the owner of the contract. 

`bookCanvasFor(uint32 _canvasId, address _bookFor)` will change the booking. Passing a zero address as a parameter will remove all the restrictions. 